### PR TITLE
w-content whitelisting and blacklisting

### DIFF
--- a/lib/components/content/Content.vue
+++ b/lib/components/content/Content.vue
@@ -1,5 +1,11 @@
 <template>
-  <div v-whppt-content="contentItems" class="whppt-contents" :class="{ 'whppt-contents--active': activeMenuItem }">
+  <div
+    v-whppt-content="contentItems"
+    :whitelist="whitelist"
+    :blacklist="blacklist"
+    class="whppt-contents"
+    :class="{ 'whppt-contents--active': activeMenuItem }"
+  >
     <div v-for="(content, index) in initContentItems" :key="`${content.key}-${index}`" class="whppt-content">
       <div v-if="activeMenuItem && !editSidebar" class="whppt-content__container container">
         <whppt-button v-whppt-spacing="content" class="whppt-contents__spacing-button">
@@ -29,6 +35,14 @@ export default {
     container: {
       type: Boolean,
       default: () => true,
+    },
+    whitelist: {
+      type: Array,
+      default: () => [],
+    },
+    blacklist: {
+      type: Array,
+      default: () => [],
     },
   },
   computed: {

--- a/lib/components/editors/Content.vue
+++ b/lib/components/editors/Content.vue
@@ -13,7 +13,7 @@
 
 <script>
 import { mapActions, mapState } from 'vuex';
-import { orderBy, find } from 'lodash';
+import { orderBy, find, filter, includes } from 'lodash';
 import WhpptButton from '../ui/Button';
 
 export default {
@@ -26,7 +26,16 @@ export default {
       if (!this.selectedComponent) return;
 
       const plugin = find(this.$whppt.plugins, p => (p.pageType && p.pageType.name) === this.page.pageType);
-      const components = [...this.$whppt.components, ...plugin.pageType.components];
+      let components = [...this.$whppt.components, ...plugin.pageType.components];
+
+      const whitelist = this.selectedComponent.whitelist;
+      const blacklist = this.selectedComponent.blacklist;
+
+      if (whitelist.length) {
+        components = filter(components, c => includes(whitelist, c.key));
+      } else if (blacklist.length) {
+        components = filter(components, c => !includes(blacklist, c.key));
+      }
 
       return orderBy(components, ['key']);
     },

--- a/lib/plugins/directives/content.js
+++ b/lib/plugins/directives/content.js
@@ -3,6 +3,9 @@ import Vue from 'vue';
 export default ({ store, app: { $whppt } }, menuIsInState, MENUSTATES) => {
   Vue.directive('whppt-content', {
     bind(el, binding) {
+      const whitelist = el.getAttribute('whitelist') ? el.getAttribute('whitelist').split(',') : [];
+      const blacklist = el.getAttribute('blacklist') ? el.getAttribute('blacklist').split(',') : [];
+
       el.addEventListener('content-selected', function(e) {
         store.dispatch('whppt-nuxt/editor/clearSelectedContent');
 
@@ -18,7 +21,7 @@ export default ({ store, app: { $whppt } }, menuIsInState, MENUSTATES) => {
 
         store.dispatch('whppt-nuxt/editor/selectComponent', {
           el,
-          value: { value: binding.value },
+          value: { value: binding.value, whitelist, blacklist },
         });
 
         store.commit('whppt-nuxt/editor/editInSidebar', 'Content');


### PR DESCRIPTION
Whitelisting and blacklisting for whppt-content. 

w-content takes whitelist['carousel'] and blacklist['richText'] props. The items inside the arrays corresponds to the key values on the registered components. If both are provided, the whitelist is prioritised.