### PR TITLE
pass container through to content to indicate root level component, s…

### DIFF
--- a/lib/components/content/Content.vue
+++ b/lib/components/content/Content.vue
@@ -6,7 +6,12 @@
           Adjust Spacing
         </whppt-button>
       </div>
-      <component :is="content.componentType" :content="content" :class="spacingClasses(content)"></component>
+      <component
+        :is="content.componentType"
+        :content="content"
+        :class="spacingClasses(content)"
+        :container="container"
+      ></component>
     </div>
   </div>
 </template>
@@ -28,7 +33,7 @@ export default {
     },
     container: {
       type: Boolean,
-      default: () => true,
+      default: true,
     },
   },
   computed: {


### PR DESCRIPTION
As per discussion, split content components generally should not have containers associated with them. We have been handling containers within custom components per site to dynamically render container classes. Default is true, since a majority of root level components are going to need a container.