### PR TITLE
Bring in context for before/after(Un)publish

### DIFF
--- a/lib/plugins/pluginDefaults.js
+++ b/lib/plugins/pluginDefaults.js
@@ -29,10 +29,11 @@ function checkSlug(collection) {
 }
 
 function publishPage(collection, beforePublish = () => Promise.resolve(), afterPublish = () => Promise.resolve()) {
-  return function({ $axios, $whppt }, { page }) {
-    return beforePublish(page).then(() => {
+  return function(context, { page }) {
+    const { $axios, $whppt } = context;
+    return beforePublish(context, { collection, id: page._id }).then(() => {
       return $axios.post(`${$whppt.apiPrefix}/page/publishPage`, { page, collection }).then(() => {
-        return afterPublish(page);
+        return afterPublish(context, { collection, id: page._id });
       });
     });
   };
@@ -43,10 +44,11 @@ function unpublishPage(
   beforeUnpublish = () => Promise.resolve(),
   afterUnpublish = () => Promise.resolve()
 ) {
-  return function({ $axios, $whppt }, { _id }) {
-    return beforeUnpublish(_id).then(() => {
+  return function(context, { _id }) {
+    const { $axios, $whppt } = context;
+    return beforeUnpublish(context, _id).then(() => {
       return $axios.$post(`${$whppt.apiPrefix}/page/unpublishPage`, { _id, collection }).then(() => {
-        return afterUnpublish(_id);
+        return afterUnpublish(context, _id);
       });
     });
   };


### PR DESCRIPTION
For publish related functions, before/afterPublish will take in collection and id instead of the whole page object