### PR TITLE
Allow for a custom class on content components

### DIFF
--- a/lib/components/content/Content.vue
+++ b/lib/components/content/Content.vue
@@ -17,6 +17,7 @@
         :content="content"
         :class="spacingClasses(content)"
         :container="container"
+        :custom-class="customClass"
       ></component>
     </div>
   </div>
@@ -33,22 +34,11 @@ export default {
     WhpptButton,
   },
   props: {
-    contentItems: {
-      type: [Array, Object],
-      required: true,
-    },
-    container: {
-      type: Boolean,
-      default: true,
-    },
-    whitelist: {
-      type: Array,
-      default: () => [],
-    },
-    blacklist: {
-      type: Array,
-      default: () => [],
-    },
+    contentItems: { type: [Array, Object], required: true },
+    container: { type: Boolean, default: true },
+    whitelist: { type: Array, default: () => [] },
+    blacklist: { type: Array, default: () => [] },
+    customClass: { type: String, default: '' },
   },
   computed: {
     ...mapState('whppt-nuxt/page', ['page']),

--- a/lib/plugins/directives/editorEnabled.js
+++ b/lib/plugins/directives/editorEnabled.js
@@ -1,17 +1,17 @@
 import Vue from 'vue';
 
 export default () => {
-  // can't observe missing attribute within other directives. 
+  // can't observe missing attribute within other directives.
   // binding false to an attribute hides the attribute in the dom
   // this directive fixes the attribute value that can't be observed,
   // by creating an additional string value attribute.
   Vue.directive('whppt-editor-enabled', {
     bind(el, binding) {
-      const value = !binding.value
+      const value = !binding.value;
       el.setAttribute('editor-disabled', value.toString());
     },
     update(el, binding) {
-      const value = !binding.value
+      const value = !binding.value;
       el.setAttribute('editor-disabled', value.toString());
     },
   });

--- a/lib/plugins/directives/link.js
+++ b/lib/plugins/directives/link.js
@@ -4,8 +4,8 @@ import SimpleComponentClickHandler from './_simpleComponentClickHandler';
 export default ({ store, app: { $whppt } }, menuIsInState, MENUSTATES) => {
   Vue.directive('whppt-link', {
     bind(el, binding) {
-      const property = el.getAttribute('data-property');
-      const value = { value: binding.value, property };
+      // const property = el.getAttribute('data-property');
+      // const value = { value: binding.value, property };
 
       let _disabled = true;
 


### PR DESCRIPTION
The custom class allows for a scenario where we could apply a site theme and then style the component differently from the website side.

see: form-builder plugin