### PR TITLE
remove base url from copy file

### DIFF
--- a/lib/components/editors/LinkEditor.vue
+++ b/lib/components/editors/LinkEditor.vue
@@ -140,10 +140,7 @@ export default {
     ...mapActions('whppt-nuxt/editor', ['setSelectedComponentState']),
     selectFile(item) {
       if (!item) return;
-
-      const baseUrl = this.baseFileUrl ? this.baseFileUrl : window.location.origin;
-
-      this.setSelectedComponentState({ value: `${baseUrl}/file/${item._id}`, path: 'href' });
+      this.setSelectedComponentState({ value: `/file/${item._id}`, path: 'href' });
       this.setSelectedComponentState({ value: item._id, path: 'fileId' });
     },
     queryFilesList() {

--- a/lib/components/system/SiteSettings/tabs/SettingsFiles.vue
+++ b/lib/components/system/SiteSettings/tabs/SettingsFiles.vue
@@ -137,8 +137,7 @@ export default {
       return encodeURI(`${baseUrl}/file/${file._id}/${file.name}`);
     },
     copyUrl(file) {
-      const baseUrl = window.location.origin;
-      const str = encodeURI(`${baseUrl}/file/${file._id}/${file.name}`);
+      const str = encodeURI(`/file/${file._id}/${file.name}`);
       const el = document.createElement('textarea');
       el.value = str;
       document.body.appendChild(el);


### PR DESCRIPTION
As suggested by terence, we need to prevent clients from copying a draft url and using it.