### PR TITLE
base url removed from file copy

### DIFF
--- a/components/lib/system/SiteSettings/tabs/SettingsFiles.vue
+++ b/components/lib/system/SiteSettings/tabs/SettingsFiles.vue
@@ -160,12 +160,10 @@ export default {
       this.loadFiles();
     },
     getUrl(file) {
-      const baseUrl = window.location.origin;
-      return encodeURI(`${baseUrl}/file/${file._id}/${file.name}`);
+      return encodeURI(`/file/${file._id}/${file.name}`);
     },
     copyUrl(file) {
-      const baseUrl = window.location.origin;
-      const str = encodeURI(`${baseUrl}/file/${file._id}/${file.name}`);
+      const str = encodeURI(`/file/${file._id}/${file.name}`);
       const el = document.createElement('textarea');
       el.value = str;
       document.body.appendChild(el);

--- a/components/lib/whpptComponents/Link.vue
+++ b/components/lib/whpptComponents/Link.vue
@@ -150,9 +150,8 @@ export default {
         this.data.fileId = '';
         return;
       }
-      const baseUrl = this.baseFileUrl ? this.baseFileUrl : window.location.origin;
 
-      this.data.href = `${baseUrl}/file/${item._id}`;
+      this.data.href = `/file/${item._id}`;
       this.data.fileId = item._id;
     },
     isTypeOf(value) {


### PR DESCRIPTION
To prevent clients from copying the draft environment url into their links.