### PR TITLE
Fixed error of empty pageType selection

### DIFF
--- a/lib/components/system/WhpptPage.vue
+++ b/lib/components/system/WhpptPage.vue
@@ -51,7 +51,7 @@
 </template>
 
 <script>
-import { map, filter, forEach, find } from 'lodash';
+import { map, filter, forEach, find, get } from 'lodash';
 import { mapState, mapActions } from 'vuex';
 import slugify from 'slugify';
 import WhpptSelect from '../ui/Select';
@@ -87,7 +87,7 @@ export default {
       return map(pageTypePlugins, t => t.pageType);
     },
     selectedPageTypePlugin() {
-      return find(pageTypePlugins, plugin => plugin.pageType.name === this.pageForm.pageType.name);
+      return find(pageTypePlugins, plugin => plugin.pageType.name === get(this.pageForm, 'pageType.name'));
     },
   },
   methods: {


### PR DESCRIPTION
When selecting the empty option in the pageType select when creating a page, this.pageForm.pageType is undefined, leading to an error