### PR TITLE
Fixes the `keyBy` in component and supports hiding spacing control

### DIFF
--- a/lib/plugins/index.js
+++ b/lib/plugins/index.js
@@ -1,7 +1,13 @@
-import { filter } from 'lodash';
-import { registerDynamicDirective, menuIsInState, MENUSTATES, setSpacings, trim } from '../util';
-import directives from './directives';
-import { Components } from './Components';
+import { filter, find, keyBy } from 'lodash'
+import {
+  registerDynamicDirective,
+  menuIsInState,
+  MENUSTATES,
+  setSpacings,
+  trim,
+} from '../util'
+import directives from './directives'
+import { Components } from './Components'
 
 import {
   checkSlug,
@@ -12,34 +18,34 @@ import {
   savePage,
   unpublishPage,
   applyRoles,
-} from './pluginDefaults';
+} from './pluginDefaults'
 
-import LoadSiteSettings from './helpers/LoadSiteSettings';
-import SaveSiteSettings from './helpers/SaveSiteSettings';
-import PublishSiteSettings from './helpers/PublishSiteSettings';
-import SaveFooter from './helpers/SaveFooter';
-import PublishFooter from './helpers/PublishFooter';
-import LoadFooter from './helpers/LoadFooter';
-import SaveNav from './helpers/SaveNav';
-import PublishNav from './helpers/PublishNav';
-import LoadNav from './helpers/LoadNav';
-import CheckSlug from './helpers/CheckSlug';
-import Select from './helpers/editors/Select';
-import Hover from './helpers/editors/Hover';
-import Image from './helpers/Image';
+import LoadSiteSettings from './helpers/LoadSiteSettings'
+import SaveSiteSettings from './helpers/SaveSiteSettings'
+import PublishSiteSettings from './helpers/PublishSiteSettings'
+import SaveFooter from './helpers/SaveFooter'
+import PublishFooter from './helpers/PublishFooter'
+import LoadFooter from './helpers/LoadFooter'
+import SaveNav from './helpers/SaveNav'
+import PublishNav from './helpers/PublishNav'
+import LoadNav from './helpers/LoadNav'
+import CheckSlug from './helpers/CheckSlug'
+import Select from './helpers/editors/Select'
+import Hover from './helpers/editors/Hover'
+import Image from './helpers/Image'
 
 // @deprecated
-import SavePage from './helpers/SavePage';
+import SavePage from './helpers/SavePage'
 // @deprecated
-import LoadPage from './helpers/LoadPage';
+import LoadPage from './helpers/LoadPage'
 // @deprecated
-import DeletePage from './helpers/DeletePage';
+import DeletePage from './helpers/DeletePage'
 // @deprecated
-import PublishPage from './helpers/PublishPage';
+import PublishPage from './helpers/PublishPage'
 // @deprecated
-import UnpublishPage from './helpers/UnpublishPage';
+import UnpublishPage from './helpers/UnpublishPage'
 
-const options = JSON.parse(`<%= JSON.stringify(options) %>`);
+const options = JSON.parse(`{"apiPrefix":"api","defaultMargin":{"top":{"base":0,"sm":0,"lg":0},"bottom":{"base":2,"sm":2,"lg":4}}}`)
 
 export default (context, inject) => {
   const whppt = (global.$whppt = {
@@ -50,34 +56,51 @@ export default (context, inject) => {
     disablePublishing: options.disablePublishing,
     getAdditionalComponents,
     addPlugin(plugin) {
-      const pageType = plugin.pageType;
-      const collection = pageType ? (pageType.collection && pageType.collection.name) || pageType.name : undefined;
+      const pageType = plugin.pageType
+      const collection = pageType
+        ? (pageType.collection && pageType.collection.name) || pageType.name
+        : undefined
 
-      if (collection && !pageType.createPage) pageType.createPage = createPage(collection);
-      if (collection && !pageType.deletePage) pageType.deletePage = deletePage(collection);
-      if (collection && !pageType.loadPage) pageType.loadPage = loadPage(collection);
-      if (collection && !pageType.savePage) pageType.savePage = savePage(collection);
-      if (collection && !pageType.checkSlug) pageType.checkSlug = checkSlug(collection);
-      if (collection && !pageType.applyRoles) pageType.applyRoles = applyRoles(collection);
+      if (collection && !pageType.createPage)
+        pageType.createPage = createPage(collection)
+      if (collection && !pageType.deletePage)
+        pageType.deletePage = deletePage(collection)
+      if (collection && !pageType.loadPage)
+        pageType.loadPage = loadPage(collection)
+      if (collection && !pageType.savePage)
+        pageType.savePage = savePage(collection)
+      if (collection && !pageType.checkSlug)
+        pageType.checkSlug = checkSlug(collection)
+      if (collection && !pageType.applyRoles)
+        pageType.applyRoles = applyRoles(collection)
       if (collection && !pageType.publishPage) {
-        pageType.publishPage = publishPage(collection, pageType.beforePublish, pageType.afterPublish);
+        pageType.publishPage = publishPage(
+          collection,
+          pageType.beforePublish,
+          pageType.afterPublish
+        )
       }
       if (collection && !pageType.unpublishPage) {
-        pageType.unpublishPage = unpublishPage(collection, pageType.beforeUnpublish, pageType.afterUnpublish);
+        pageType.unpublishPage = unpublishPage(
+          collection,
+          pageType.beforeUnpublish,
+          pageType.afterUnpublish
+        )
       }
 
-      this.plugins[plugin.name] = plugin;
+      this.plugins[plugin.name] = plugin
 
       if (plugin.editors) {
         for (const editor of plugin.editors) {
-          if (editor.directive) return editor.directive(context, menuIsInState, MENUSTATES, editor);
-          registerDynamicDirective(context, menuIsInState, MENUSTATES, editor);
+          if (editor.directive)
+            return editor.directive(context, menuIsInState, MENUSTATES, editor)
+          registerDynamicDirective(context, menuIsInState, MENUSTATES, editor)
         }
       }
     },
-  });
+  })
 
-  const { store } = context;
+  const { store } = context
 
   Object.assign(global.$whppt, {
     loadSiteSettings: LoadSiteSettings(context),
@@ -96,6 +119,7 @@ export default (context, inject) => {
     saveNav: SaveNav(context),
     publishNav: PublishNav(context),
     components: Components(options),
+    getComponentDefinitions,
     spacing: setSpacings(options),
     trim,
     defaultPadding: options.defaultPadding || {
@@ -106,68 +130,84 @@ export default (context, inject) => {
       top: { base: 0, sm: 2, lg: 4 },
       bottom: { base: 0, sm: 2, lg: 4 },
     },
-  });
+  })
 
-  Select(whppt);
-  Hover(whppt);
-  Image(whppt, store.state[`whppt/editor`].baseImageUrl, store.state[`whppt/editor`].baseCdnImageUrl);
+  Select(whppt)
+  Hover(whppt)
+  Image(
+    whppt,
+    store.state[`whppt/editor`].baseImageUrl,
+    store.state[`whppt/editor`].baseCdnImageUrl
+  )
 
-  context.app.$whppt = whppt;
-  inject('whppt', whppt);
+  context.app.$whppt = whppt
+  inject('whppt', whppt)
 
   const dynamicDirectives = [
     { name: 'whppt-text', componentName: 'PlainText' },
     { name: 'whppt-anchor', componentName: 'Anchor' },
     { name: 'whppt-formatted-text', componentName: 'FormattedText' },
     { name: 'whppt-spacing', componentName: 'SpacingControls' },
-  ];
+  ]
 
   for (const directive of dynamicDirectives) {
-    registerDynamicDirective(context, menuIsInState, MENUSTATES, directive);
+    registerDynamicDirective(context, menuIsInState, MENUSTATES, directive)
   }
 
-  directives.content(context, menuIsInState, MENUSTATES);
-  directives.date(context, menuIsInState, MENUSTATES);
-  directives.image(context, menuIsInState, MENUSTATES);
-  directives.link(context, menuIsInState, MENUSTATES);
-  directives.list(context, menuIsInState, MENUSTATES);
-  directives.select(context, menuIsInState, MENUSTATES);
-  directives.richText(context, menuIsInState, MENUSTATES);
-  directives.actions(context, menuIsInState, MENUSTATES);
-  directives.editorEnabled();
-};
+  directives.content(context, menuIsInState, MENUSTATES)
+  directives.date(context, menuIsInState, MENUSTATES)
+  directives.image(context, menuIsInState, MENUSTATES)
+  directives.link(context, menuIsInState, MENUSTATES)
+  directives.list(context, menuIsInState, MENUSTATES)
+  directives.select(context, menuIsInState, MENUSTATES)
+  directives.richText(context, menuIsInState, MENUSTATES)
+  directives.actions(context, menuIsInState, MENUSTATES)
+  directives.editorEnabled()
+}
 
 // type can be siteSettings, pageSettings, dashboard, editors.
 function getAdditionalComponents(type) {
-  const additionalTabs = [];
-  const additionalComponents = {};
+  const additionalTabs = []
+  const additionalComponents = {}
 
-  const whpptPlugins = filter(global.$whppt.plugins, t => t[type]);
+  const whpptPlugins = filter(global.$whppt.plugins, (t) => t[type])
 
   for (const plugin of whpptPlugins) {
-    const settings = Array.isArray(plugin[type]) ? plugin[type] : [plugin[type]];
+    const settings = Array.isArray(plugin[type]) ? plugin[type] : [plugin[type]]
 
     if (type === 'editors') {
       for (const editor of settings) {
         // key will be the identifier moving forwards into 2.0 release
         // editor.name is compatibility
-        const key = editor.key || editor.name;
+        const key = editor.key || editor.name
 
-        if (key && editor.component) additionalComponents[key] = editor.component;
+        if (key && editor.component)
+          additionalComponents[key] = editor.component
       }
     }
 
     for (const setting of settings) {
       // key will be the identifier moving forwards into 2.0 release
       // setting.name is compatibility
-      const key = setting.key || setting.name;
+      const key = setting.key || setting.name
 
       if (setting && key) {
-        additionalComponents[key] = setting.component;
-        additionalTabs.push({ name: key, label: setting.label });
+        additionalComponents[key] = setting.component
+        additionalTabs.push({ name: key, label: setting.label })
       }
     }
   }
 
-  return { additionalComponents, additionalTabs };
+  return { additionalComponents, additionalTabs }
+}
+
+function getComponentDefinitions(pageType) {
+  const plugin = find(
+    this.plugins,
+    (p) => (p.pageType && p.pageType.name) === pageType
+  )
+  return keyBy(
+    [...this.components, ...plugin.pageType.components],
+    (c) => c.componentType
+  )
 }

--- a/lib/plugins/index.js
+++ b/lib/plugins/index.js
@@ -1,13 +1,7 @@
-import { filter, find, keyBy } from 'lodash'
-import {
-  registerDynamicDirective,
-  menuIsInState,
-  MENUSTATES,
-  setSpacings,
-  trim,
-} from '../util'
-import directives from './directives'
-import { Components } from './Components'
+import { filter, find, keyBy } from 'lodash';
+import { registerDynamicDirective, menuIsInState, MENUSTATES, setSpacings, trim } from '../util';
+import directives from './directives';
+import { Components } from './Components';
 
 import {
   checkSlug,
@@ -18,34 +12,34 @@ import {
   savePage,
   unpublishPage,
   applyRoles,
-} from './pluginDefaults'
+} from './pluginDefaults';
 
-import LoadSiteSettings from './helpers/LoadSiteSettings'
-import SaveSiteSettings from './helpers/SaveSiteSettings'
-import PublishSiteSettings from './helpers/PublishSiteSettings'
-import SaveFooter from './helpers/SaveFooter'
-import PublishFooter from './helpers/PublishFooter'
-import LoadFooter from './helpers/LoadFooter'
-import SaveNav from './helpers/SaveNav'
-import PublishNav from './helpers/PublishNav'
-import LoadNav from './helpers/LoadNav'
-import CheckSlug from './helpers/CheckSlug'
-import Select from './helpers/editors/Select'
-import Hover from './helpers/editors/Hover'
-import Image from './helpers/Image'
+import LoadSiteSettings from './helpers/LoadSiteSettings';
+import SaveSiteSettings from './helpers/SaveSiteSettings';
+import PublishSiteSettings from './helpers/PublishSiteSettings';
+import SaveFooter from './helpers/SaveFooter';
+import PublishFooter from './helpers/PublishFooter';
+import LoadFooter from './helpers/LoadFooter';
+import SaveNav from './helpers/SaveNav';
+import PublishNav from './helpers/PublishNav';
+import LoadNav from './helpers/LoadNav';
+import CheckSlug from './helpers/CheckSlug';
+import Select from './helpers/editors/Select';
+import Hover from './helpers/editors/Hover';
+import Image from './helpers/Image';
 
 // @deprecated
-import SavePage from './helpers/SavePage'
+import SavePage from './helpers/SavePage';
 // @deprecated
-import LoadPage from './helpers/LoadPage'
+import LoadPage from './helpers/LoadPage';
 // @deprecated
-import DeletePage from './helpers/DeletePage'
+import DeletePage from './helpers/DeletePage';
 // @deprecated
-import PublishPage from './helpers/PublishPage'
+import PublishPage from './helpers/PublishPage';
 // @deprecated
-import UnpublishPage from './helpers/UnpublishPage'
+import UnpublishPage from './helpers/UnpublishPage';
 
-const options = JSON.parse(`{"apiPrefix":"api","defaultMargin":{"top":{"base":0,"sm":0,"lg":0},"bottom":{"base":2,"sm":2,"lg":4}}}`)
+const options = JSON.parse(`<%= JSON.stringify(options) %>`);
 
 export default (context, inject) => {
   const whppt = (global.$whppt = {
@@ -56,51 +50,34 @@ export default (context, inject) => {
     disablePublishing: options.disablePublishing,
     getAdditionalComponents,
     addPlugin(plugin) {
-      const pageType = plugin.pageType
-      const collection = pageType
-        ? (pageType.collection && pageType.collection.name) || pageType.name
-        : undefined
+      const pageType = plugin.pageType;
+      const collection = pageType ? (pageType.collection && pageType.collection.name) || pageType.name : undefined;
 
-      if (collection && !pageType.createPage)
-        pageType.createPage = createPage(collection)
-      if (collection && !pageType.deletePage)
-        pageType.deletePage = deletePage(collection)
-      if (collection && !pageType.loadPage)
-        pageType.loadPage = loadPage(collection)
-      if (collection && !pageType.savePage)
-        pageType.savePage = savePage(collection)
-      if (collection && !pageType.checkSlug)
-        pageType.checkSlug = checkSlug(collection)
-      if (collection && !pageType.applyRoles)
-        pageType.applyRoles = applyRoles(collection)
+      if (collection && !pageType.createPage) pageType.createPage = createPage(collection);
+      if (collection && !pageType.deletePage) pageType.deletePage = deletePage(collection);
+      if (collection && !pageType.loadPage) pageType.loadPage = loadPage(collection);
+      if (collection && !pageType.savePage) pageType.savePage = savePage(collection);
+      if (collection && !pageType.checkSlug) pageType.checkSlug = checkSlug(collection);
+      if (collection && !pageType.applyRoles) pageType.applyRoles = applyRoles(collection);
       if (collection && !pageType.publishPage) {
-        pageType.publishPage = publishPage(
-          collection,
-          pageType.beforePublish,
-          pageType.afterPublish
-        )
+        pageType.publishPage = publishPage(collection, pageType.beforePublish, pageType.afterPublish);
       }
       if (collection && !pageType.unpublishPage) {
-        pageType.unpublishPage = unpublishPage(
-          collection,
-          pageType.beforeUnpublish,
-          pageType.afterUnpublish
-        )
+        pageType.unpublishPage = unpublishPage(collection, pageType.beforeUnpublish, pageType.afterUnpublish);
       }
 
-      this.plugins[plugin.name] = plugin
+      this.plugins[plugin.name] = plugin;
 
       if (plugin.editors) {
         for (const editor of plugin.editors) {
-          if (editor.directive)
-            return editor.directive(context, menuIsInState, MENUSTATES, editor)
-          registerDynamicDirective(context, menuIsInState, MENUSTATES, editor)
+          if (editor.directive) return editor.directive(context, menuIsInState, MENUSTATES, editor);
+          registerDynamicDirective(context, menuIsInState, MENUSTATES, editor);
         }
       }
     },
-  })
+  });
 
-  const { store } = context
+  const { store } = context;
 
   Object.assign(global.$whppt, {
     loadSiteSettings: LoadSiteSettings(context),
@@ -130,84 +107,73 @@ export default (context, inject) => {
       top: { base: 0, sm: 2, lg: 4 },
       bottom: { base: 0, sm: 2, lg: 4 },
     },
-  })
+  });
 
-  Select(whppt)
-  Hover(whppt)
-  Image(
-    whppt,
-    store.state[`whppt/editor`].baseImageUrl,
-    store.state[`whppt/editor`].baseCdnImageUrl
-  )
+  Select(whppt);
+  Hover(whppt);
+  Image(whppt, store.state[`whppt/editor`].baseImageUrl, store.state[`whppt/editor`].baseCdnImageUrl);
 
-  context.app.$whppt = whppt
-  inject('whppt', whppt)
+  context.app.$whppt = whppt;
+  inject('whppt', whppt);
 
   const dynamicDirectives = [
     { name: 'whppt-text', componentName: 'PlainText' },
     { name: 'whppt-anchor', componentName: 'Anchor' },
     { name: 'whppt-formatted-text', componentName: 'FormattedText' },
     { name: 'whppt-spacing', componentName: 'SpacingControls' },
-  ]
+  ];
 
   for (const directive of dynamicDirectives) {
-    registerDynamicDirective(context, menuIsInState, MENUSTATES, directive)
+    registerDynamicDirective(context, menuIsInState, MENUSTATES, directive);
   }
 
-  directives.content(context, menuIsInState, MENUSTATES)
-  directives.date(context, menuIsInState, MENUSTATES)
-  directives.image(context, menuIsInState, MENUSTATES)
-  directives.link(context, menuIsInState, MENUSTATES)
-  directives.list(context, menuIsInState, MENUSTATES)
-  directives.select(context, menuIsInState, MENUSTATES)
-  directives.richText(context, menuIsInState, MENUSTATES)
-  directives.actions(context, menuIsInState, MENUSTATES)
-  directives.editorEnabled()
-}
+  directives.content(context, menuIsInState, MENUSTATES);
+  directives.date(context, menuIsInState, MENUSTATES);
+  directives.image(context, menuIsInState, MENUSTATES);
+  directives.link(context, menuIsInState, MENUSTATES);
+  directives.list(context, menuIsInState, MENUSTATES);
+  directives.select(context, menuIsInState, MENUSTATES);
+  directives.richText(context, menuIsInState, MENUSTATES);
+  directives.actions(context, menuIsInState, MENUSTATES);
+  directives.editorEnabled();
+};
 
 // type can be siteSettings, pageSettings, dashboard, editors.
 function getAdditionalComponents(type) {
-  const additionalTabs = []
-  const additionalComponents = {}
+  const additionalTabs = [];
+  const additionalComponents = {};
 
-  const whpptPlugins = filter(global.$whppt.plugins, (t) => t[type])
+  const whpptPlugins = filter(global.$whppt.plugins, t => t[type]);
 
   for (const plugin of whpptPlugins) {
-    const settings = Array.isArray(plugin[type]) ? plugin[type] : [plugin[type]]
+    const settings = Array.isArray(plugin[type]) ? plugin[type] : [plugin[type]];
 
     if (type === 'editors') {
       for (const editor of settings) {
         // key will be the identifier moving forwards into 2.0 release
         // editor.name is compatibility
-        const key = editor.key || editor.name
+        const key = editor.key || editor.name;
 
-        if (key && editor.component)
-          additionalComponents[key] = editor.component
+        if (key && editor.component) additionalComponents[key] = editor.component;
       }
     }
 
     for (const setting of settings) {
       // key will be the identifier moving forwards into 2.0 release
       // setting.name is compatibility
-      const key = setting.key || setting.name
+      const key = setting.key || setting.name;
 
       if (setting && key) {
-        additionalComponents[key] = setting.component
-        additionalTabs.push({ name: key, label: setting.label })
+        additionalComponents[key] = setting.component;
+        additionalTabs.push({ name: key, label: setting.label });
       }
     }
   }
 
-  return { additionalComponents, additionalTabs }
+  return { additionalComponents, additionalTabs };
 }
 
 function getComponentDefinitions(pageType) {
-  const plugin = find(
-    this.plugins,
-    (p) => (p.pageType && p.pageType.name) === pageType
-  )
-  return keyBy(
-    [...this.components, ...plugin.pageType.components],
-    (c) => c.componentType
-  )
+  const plugin = find(this.plugins, p => (p.pageType && p.pageType.name) === pageType);
+  return keyBy([...this.components, ...plugin.pageType.components], c => c.componentType);
 }


### PR DESCRIPTION
1. Created a global `getComponentDefinitions` function to fix the `keyBy` in Content.vue that is not getting the whole list of components
2. Supports `hideSpacingInContent` in component definitions to hide the spacing control of that component, and ignore default margin/padding settings