### PR TITLE
Not to trim the date picker input event

### DIFF
--- a/lib/components/editors/Date.vue
+++ b/lib/components/editors/Date.vue
@@ -22,7 +22,7 @@ export default {
   methods: {
     ...mapActions('whppt/editor', ['setSelectedComponentState']),
     onInput($event) {
-      this.setSelectedComponentState({ value: this.$whppt.trim($event), path: this.selectedComponent.property });
+      this.setSelectedComponentState({ value: $event, path: this.selectedComponent.property });
     },
   },
 };


### PR DESCRIPTION
The input event is a date object, calling the `.trim()` function will lead to an error