### PR TITLE
Set the alt text in imageOptions props passed in

### DIFF
--- a/lib/components/editors/EditImage/Cropping.vue
+++ b/lib/components/editors/EditImage/Cropping.vue
@@ -20,7 +20,7 @@
       :value="imageOptions.alt"
       placeholder="e.g. Article Heading Image"
       label="Image alt text"
-      @input="setSelectedComponentState({ value: $event, path: 'image.alt' })"
+      @input="$event => (imageOptions.alt = $event)"
     />
   </div>
 </template>


### PR DESCRIPTION
Instead of setting onto the `selectedComponent` with a path. #41 