### PR TITLE
Fixed the store state mutation error when saving page

### DIFF
--- a/lib/store/modules/page.js
+++ b/lib/store/modules/page.js
@@ -19,7 +19,7 @@ export default options => ({
   }),
   actions: {
     savePage({ commit, state }, page) {
-      const _page = page || state.page;
+      const _page = cloneDeep(page || state.page);
       _page.pageType = _page.pageType || 'page';
 
       return this.$whppt.page.save(_page).then(savedPage => {


### PR DESCRIPTION
The property `updateAt` of `page` in store state gets overwritten when saving page. Solved by deep cloning