### PR TITLE
Scrolling in whppt modal won't be cut off

### DIFF
--- a/lib/components/ui/components/Dialog.vue
+++ b/lib/components/ui/components/Dialog.vue
@@ -162,6 +162,8 @@ $gray-900: #1a202c;
       border: none;
       border-radius: 0;
       max-width: unset;
+      display: flex;
+      flex-direction: column;
     }
 
     .whppt-modal__content {


### PR DESCRIPTION
To address the issue where site map expanded beyond 10 items per page will be cut off at the bottom